### PR TITLE
避免自定义命名空间前缀导致Swagger分组冲突问题

### DIFF
--- a/src/00_Host/Host.Web/Swagger/Conventions/ApiExplorerGroupPerVersionConvention.cs
+++ b/src/00_Host/Host.Web/Swagger/Conventions/ApiExplorerGroupPerVersionConvention.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc.ApplicationModels;
+using Microsoft.AspNetCore.Mvc.ApplicationModels;
+using System.Text.RegularExpressions;
 
 namespace Mkh.Host.Web.Swagger.Conventions;
 

--- a/src/00_Host/Host.Web/Swagger/Conventions/ApiExplorerGroupPerVersionConvention.cs
+++ b/src/00_Host/Host.Web/Swagger/Conventions/ApiExplorerGroupPerVersionConvention.cs
@@ -12,7 +12,14 @@ public class ApiExplorerGroupConvention : IControllerModelConvention
         if (controller.ControllerType.Namespace.IsNull())
             return;
 
-        string[] array = controller.ControllerType.FullName.Split('.');
-        controller.ApiExplorer.GroupName = array[2].ToLower();
+        /*
+         按照命名规范，假如前缀定义 xx.xx, 如：xx.xx.Mod.{模块名}.Web 时，按array[2]索引取分组的方式，
+         将导致分组冲突（No operations defined in spec）
+         */
+        var fname = controller.ControllerType.FullName;
+        var reg = Regex.Match(fname, "[.]+Mod[.]");
+        fname = reg.Success ? fname.Substring(reg.Index + reg.Length) : fname;
+        string[] array = fname.Split('.');
+        controller.ApiExplorer.GroupName = array.Length > 0 ? array[0].ToLower() : fname;
     }
 }


### PR DESCRIPTION
自定义命名空间前缀导致Swagger分组冲突问题，异常：No operations defined in spec