### PR TITLE
Update DictGroupController.cs

### DIFF
--- a/modules/00_Admin/Admin.Web/Controllers/DictGroupController.cs
+++ b/modules/00_Admin/Admin.Web/Controllers/DictGroupController.cs
@@ -21,10 +21,19 @@ public class DictGroupController : Web.ModuleController
     }
 
     /// <summary>
+    /// 分页查询
+    /// </summary>
+    [HttpGet]
+    public Task<PagingQueryResultModel<DictGroupEntity>> QueryToPagination([FromQuery] DictGroupQueryDto dto)
+    {
+        return _service.QueryToPagination(dto);
+    }
+
+    /// <summary>
     /// 查询
     /// </summary>
     [HttpGet]
-    public Task<PagingQueryResultModel<DictGroupEntity>> Query([FromQuery] DictGroupQueryDto dto)
+    public Task<IResultModel<IList<DictGroupEntity>>> Query([FromQuery] DictGroupQueryDto dto)
     {
         return _service.Query(dto);
     }


### PR DESCRIPTION
m-list 绑定结构不适用于PagingQueryResultModel<T>返回类型，该问题将导致数据字典分组列表不可用