### PR TITLE
Update DictGroupService.cs

### DIFF
--- a/modules/00_Admin/Admin.Core/Application/DictGroup/DictGroupService.cs
+++ b/modules/00_Admin/Admin.Core/Application/DictGroup/DictGroupService.cs
@@ -24,11 +24,29 @@ public class DictGroupService : IDictGroupService
         _localizer = localizer;
     }
 
-    public Task<PagingQueryResultModel<DictGroupEntity>> Query(DictGroupQueryDto dto)
+    /// <summary>
+    /// 分页查询
+    /// </summary>
+    /// <param name="dto"></param>
+    /// <returns></returns>
+    public Task<PagingQueryResultModel<DictGroupEntity>> QueryToPagination(DictGroupQueryDto dto)
     {
         var query = _repository.Find();
         query.WhereNotNull(dto.Name, m => m.Name.Equals(dto.Name));
         return query.ToPaginationResult(dto.Paging);
+    }
+
+    /// <summary>
+    /// 查询
+    /// </summary>
+    /// <param name="dto"></param>
+    /// <returns></returns>
+    public async Task<IResultModel<IList<DictGroupEntity>>> Query(DictGroupQueryDto dto)
+    {
+        var query = _repository.Find();
+        query.WhereNotNull(dto.Name, m => m.Name.Equals(dto.Name));
+        var result = await query.ToList();
+        return ResultModel.Success(result);
     }
 
     public async Task<IResultModel> Add(DictGroupAddDto dto)


### PR DESCRIPTION
m-list 绑定结构不适用于PagingQueryResultModel<T>返回类型，该问题将导致数据字典分组列表不可用