### PR TITLE
Update IDictGroupService.cs

### DIFF
--- a/modules/00_Admin/Admin.Core/Application/DictGroup/IDictGroupService.cs
+++ b/modules/00_Admin/Admin.Core/Application/DictGroup/IDictGroupService.cs
@@ -11,11 +11,18 @@ namespace Mkh.Mod.Admin.Core.Application.DictGroup;
 public interface IDictGroupService
 {
     /// <summary>
+    /// 分页查询
+    /// </summary>
+    /// <param name="dto"></param>
+    /// <returns></returns>
+    Task<PagingQueryResultModel<DictGroupEntity>> QueryToPagination(DictGroupQueryDto dto);
+
+    /// <summary>
     /// 查询
     /// </summary>
     /// <param name="dto"></param>
     /// <returns></returns>
-    Task<PagingQueryResultModel<DictGroupEntity>> Query(DictGroupQueryDto dto);
+    Task<IResultModel<IList<DictGroupEntity>>> Query(DictGroupQueryDto dto);
 
     /// <summary>
     /// 添加


### PR DESCRIPTION
m-list 绑定结构不适用于PagingQueryResultModel<T>返回类型，该问题将导致数据字典分组列表不可用